### PR TITLE
Structured repo

### DIFF
--- a/Docs/DevelopmentDesign.md
+++ b/Docs/DevelopmentDesign.md
@@ -4,7 +4,7 @@
 - [x] Output the structured json data using directory?
     - In this way, for every json, we can find its parent and grandparents till root. Thus, we might know more detail information regarding the code.
     - Use a TREE_JSON to alternate between tree and list modes
-- [ ] Use a public LLM to comment
+- [x] Use a public LLM to comment
     - [x] 考虑汇总信息、以及每个文件夹的分析(`xxx.py.analyze.md`)是否使用JSON格式(`xxx.py.analyze.json`)
         - ChatGLM4的json模式输出没有包含所有内容，放弃
     - [x] Use ZhipuAI LLM API
@@ -23,6 +23,7 @@
 - [x] Write comments in a json
 - [ ] 加上对于 Java, JavaScript, TypeScript, Go, C, C++ 等语言的解析
     - [ ] 考虑使用tree-sitter： https://github.com/tree-sitter/tree-sitter
+    - [ ] 调研增量代码问题
 - [ ] 更新base LLM
     - [ ] 找一个不计算输入token，只计算输出token的LLM
         - [ ] Adjust prompt accordingly.

--- a/Docs/DevelopmentDesign.md
+++ b/Docs/DevelopmentDesign.md
@@ -21,6 +21,13 @@
         - [ ] 需要在类上面加上注释
 - [x] Write prompt to comment
 - [x] Write comments in a json
-- [ ] Write comments back into the file
+- [ ] 加上对于 Java, JavaScript, TypeScript, Go, C, C++ 等语言的解析
+    - [ ] 考虑使用tree-sitter： https://github.com/tree-sitter/tree-sitter
+- [ ] 更新base LLM
+    - [ ] 找一个不计算输入token，只计算输出token的LLM
+        - [ ] Adjust prompt accordingly.
+    - [ ] Use a private LLM through ollama to comment
+        - [ ] Adjust prompt accordingly.
+- [ ] Write comments back into the file? (暂时先不考虑，因为这个是侵入性的，而且不可以复用)
     - [ ] Write-back should occur backward
-- [ ] Use a private LLM through ollama to comment
+

--- a/Docs/DevelopmentDesign.md
+++ b/Docs/DevelopmentDesign.md
@@ -23,8 +23,11 @@
 - [x] Write comments in a json
 - [ ] 加上对于 Java, JavaScript, TypeScript, Go, C, C++ 等语言的解析
     - [ ] 考虑使用tree-sitter： https://github.com/tree-sitter/tree-sitter
-    - [ ] 调研增量代码问题
-- [ ] 更新base LLM
+- [ ] Epic: 调研增量代码问题
+    - [ ] 增量代码考虑 tree-sitter 的能力
+    - [ ] 增量代码的元数据和 git commit 的关系对应
+    - [ ] 增量代码的元数据在尽量少的元数据情况下更新
+- [ ] 更新 base LLM
     - [ ] 找一个不计算输入token，只计算输出token的LLM
         - [ ] Adjust prompt accordingly.
     - [ ] Use a private LLM through ollama to comment

--- a/Docs/Usage.md
+++ b/Docs/Usage.md
@@ -12,6 +12,7 @@
 # # 可选：自定义分析文件所在的文件夹
 # LLM_PROJECT_HELPER_PROJECT_ROOT="~/.llm-project-helper/"
 
+LOCAL_REPO_FOLDER="/home/yourname/code"
 REPO_PATH="/your/repo/path/"
 ZHIPUAI_API_KEY="xxx.yyy"
 ```

--- a/llm_project_helper/const.py
+++ b/llm_project_helper/const.py
@@ -55,7 +55,7 @@ LLM_PROJECT_HELPER_ROOT = get_llm_project_helper_root()  # Dependent on LLM_PROJ
 WORKSPACE_DIR = os.path.join(LLM_PROJECT_HELPER_ROOT, "workspaces")
 
 # a list that list all available SaaS code repository such as github.com, gitlab.com, gitee.com
-AVAILABLE_SAAS = ["github.com", "gitlab.com", "gitee.com"]
+AVAILABLE_SAAS = ["github.com", "gitee.com", "gitlab.com", "jihulab.com"]
 
 # Prompts
 

--- a/llm_project_helper/repo_traverser.py
+++ b/llm_project_helper/repo_traverser.py
@@ -1,6 +1,5 @@
 import os
 import json
-import shutil
 from dotenv import load_dotenv
 from llm_project_helper.parser.python_parser import python_analyze_code
 from loguru import logger
@@ -34,7 +33,7 @@ class RepoTraverser:
                 repo_name = self.repo_path.split(saas)[-1]
                 repo_name = saas + repo_name
                 break
-        
+
         logger.info(f"repo_name from get_cur_ws_dir: {repo_name}")
 
         cur_ws_dir = os.path.join(workspaces_dir, repo_name)

--- a/llm_project_helper/repo_traverser.py
+++ b/llm_project_helper/repo_traverser.py
@@ -76,8 +76,8 @@ class RepoTraverser:
                             os.makedirs(cur_file_path)
                         json_file = os.path.join(cur_file_path, py_path + '.json')
 
-                        # # 目前是临时的直接拷贝，后续需要通过规则获取源文件，或者记录在json文件中
-                        # # TODO: 在sectioned_comment通过规则获取源文件
+                        # # 之前是临时的直接拷贝，后续需要通过规则获取源文件，或者记录在json文件中
+                        # # DONE: 在sectioned_comment通过规则获取源文件
                         # src_file = os.path.join(src_file_path, py_path)
                         # # copy the src_file to cur_file_path
                         # shutil.copy2(src_file, os.path.join(cur_file_path, py_path))
@@ -102,7 +102,7 @@ class RepoTraverser:
                 # save result in the folder as file_path, add only the suffix .analyze.md
                 analyze_file = file_path.replace('.json', '.analyze.md')
                 # if the file exists, skip the analyze and continue
-                # TODO: if FORCE_RE_ANALYZE is on, then re-do the analysis
+                # DONE: if FORCE_RE_ANALYZE is on, then re-do the analysis
                 if os.path.exists(analyze_file) and not FORCE_RE_ANALYZE:
                     continue
                 file_summary_analyzer = FileSummaryAnalyzer()
@@ -123,7 +123,7 @@ class RepoTraverser:
                 # save result in the folder as file_path, add only the suffix .comments.json
                 analyze_file = file_path.replace('.json', '.comments.json')
                 # if the file exists, skip the analyze and continue
-                # TODO: if FORCE_RE_COMMENT is on, then re-do the analysis
+                # DONE: if FORCE_RE_COMMENT is on, then re-do the analysis
                 if os.path.exists(analyze_file) and not FORCE_RE_COMMENT:
                     continue
                 # get relevant summary file: *.py.analyze.md
@@ -141,7 +141,7 @@ class RepoTraverser:
                 comments = code_section_analyzer.analyze_code_section(file_path, summary_file, code_file)
                 logger.info(f"Comments of file {code_file} is:\n {comments}")
                 result = {
-                    "file_path": code_file,  # TODO: 这里的code_file需要使用SaaS地址+群组+项目+文件名方式
+                    "file_path": code_file,  # DONE: 这里的code_file需要使用SaaS地址+群组+项目+文件名方式
                     "comments": comments
                 }
                 with open(analyze_file, 'w', encoding='utf-8') as f:

--- a/llm_project_helper/repo_traverser.py
+++ b/llm_project_helper/repo_traverser.py
@@ -6,22 +6,37 @@ from llm_project_helper.parser.python_parser import python_analyze_code
 from loguru import logger
 from llm_project_helper.analyzer.file_summary_analyzer import FileSummaryAnalyzer
 from llm_project_helper.analyzer.code_section_analyzer import CodeSectionAnalyzer
-from llm_project_helper.const import TREE_JSON, FORCE_RE_ANALYZE, FORCE_RE_COMMENT
+from llm_project_helper.const import TREE_JSON, FORCE_RE_ANALYZE, FORCE_RE_COMMENT, AVAILABLE_SAAS, WORKSPACE_DIR
+
+load_dotenv()
 
 
 class RepoTraverser:
     def __init__(self):
-        load_dotenv()
         self.repo_path = os.getenv("REPO_PATH")
 
-    def get_cur_ws_dir(self, workspaces_dir):
+    def get_cur_ws_dir(self):
         if not self.repo_path:
             raise ValueError("Repository path not configured in .env file")
+        workspaces_dir = WORKSPACE_DIR
+        logger.info(f"workspaces_dir: {workspaces_dir}")
 
         # get the last part of the repo path, seperated by '/' or '\'
         repo_name = self.repo_path.split(os.sep)[-1]
         if len(repo_name) == 0:
             repo_name = self.repo_path.split(os.sep)[-2]
+
+        # REPO_PATH="/home/richardliu/code/github.com/LargeWorldModel/LWM"
+        # find if REPO_PATH contains aviailable SAAS. If so, then use the last part of the path(including the avaible saas) as the repo_name
+        for saas in AVAILABLE_SAAS:
+            if saas in self.repo_path:
+                logger.info(f"repo_path contains saas: {saas}")
+                repo_name = self.repo_path.split(saas)[-1]
+                repo_name = saas + repo_name
+                break
+        
+        logger.info(f"repo_name from get_cur_ws_dir: {repo_name}")
+
         cur_ws_dir = os.path.join(workspaces_dir, repo_name)
         # create workspaces_dir if not exists
         if not os.path.exists(cur_ws_dir):
@@ -29,8 +44,8 @@ class RepoTraverser:
             os.makedirs(cur_ws_dir)
         return cur_ws_dir
 
-    def traverse_repo(self, workspaces_dir):
-        cur_ws_dir = self.get_cur_ws_dir(workspaces_dir)
+    def traverse_repo(self):
+        cur_ws_dir = self.get_cur_ws_dir()
 
         for root, dirs, files in os.walk(self.repo_path):
             for file in files:
@@ -55,17 +70,17 @@ class RepoTraverser:
                         folder_path = relative_path.replace(py_path, '')
 
                         cur_file_path = os.path.join(cur_ws_dir, folder_path)
-                        src_file_path = os.path.join(self.repo_path, folder_path)
+                        # src_file_path = os.path.join(self.repo_path, folder_path)
                         if not os.path.exists(cur_file_path):
                             logger.debug(f'Creating folder: {cur_file_path}')
                             os.makedirs(cur_file_path)
                         json_file = os.path.join(cur_file_path, py_path + '.json')
 
-                        # 目前是临时的直接拷贝，后续需要通过规则获取源文件，或者记录在json文件中
-                        # TODO: 在sectioned_comment通过规则获取源文件
-                        src_file = os.path.join(src_file_path, py_path)
-                        # copy the src_file to cur_file_path
-                        shutil.copy2(src_file, os.path.join(cur_file_path, py_path))
+                        # # 目前是临时的直接拷贝，后续需要通过规则获取源文件，或者记录在json文件中
+                        # # TODO: 在sectioned_comment通过规则获取源文件
+                        # src_file = os.path.join(src_file_path, py_path)
+                        # # copy the src_file to cur_file_path
+                        # shutil.copy2(src_file, os.path.join(cur_file_path, py_path))
 
                     with open(os.path.join(cur_ws_dir, json_file), 'w') as f:
                         json.dump(output, f, indent=4)
@@ -115,12 +130,18 @@ class RepoTraverser:
                 summary_file = file_path.replace('.json', '.analyze.md')
                 # get relevant code file:
                 code_file = file_path.replace('.json', '')
+                local_repo_folder = os.getenv("LOCAL_REPO_FOLDER")
+                # # if local_repo_folder does not have trailing os.sep, add it. AS WORKSPACE_DIR does not have trailing os.sep, this is not needed
+                # if local_repo_folder[-1] != os.sep:
+                #     local_repo_folder += os.sep
+                code_file = code_file.replace(WORKSPACE_DIR, local_repo_folder)
+                logger.info(f"code_file: {code_file}")
 
                 code_section_analyzer = CodeSectionAnalyzer()
                 comments = code_section_analyzer.analyze_code_section(file_path, summary_file, code_file)
                 logger.info(f"Comments of file {code_file} is:\n {comments}")
                 result = {
-                    "file_path": code_file,
+                    "file_path": code_file,  # TODO: 这里的code_file需要使用SaaS地址+群组+项目+文件名方式
                     "comments": comments
                 }
                 with open(analyze_file, 'w', encoding='utf-8') as f:

--- a/main.py
+++ b/main.py
@@ -2,24 +2,22 @@ import os
 
 from llm_project_helper import RepoTraverser
 from llm_project_helper.logs import logger
-import llm_project_helper.const
 
 from dotenv import load_dotenv
 load_dotenv()
 
-WORKSPACE_DIR = "workspaces"
 
 if __name__ == '__main__':
     traverser = RepoTraverser()
 
-    # concat current folder with workspaces; if env defined a home folder, then use that
-    workspaces_dir = os.path.join(os.getcwd(), WORKSPACE_DIR)
-    if (llm_project_helper.const.HOME_FOLDER_WORKSPACE_FLAG):
-        workspaces_dir = llm_project_helper.const.WORKSPACE_DIR
-    logger.info(f"workspaces_dir: {workspaces_dir}")
+    # # concat current folder with workspaces; if env defined a home folder, then use that
+    # workspaces_dir = os.path.join(os.getcwd(), WORKSPACE_DIR)
+    # if (llm_project_helper.const.HOME_FOLDER_WORKSPACE_FLAG):
+    #     workspaces_dir = llm_project_helper.const.WORKSPACE_DIR
+    # logger.info(f"workspaces_dir: {workspaces_dir}")
 
     # 1. Doing the structure analyzation. LLM is not USED HERE
-    analyze_folder = traverser.traverse_repo(workspaces_dir)
+    analyze_folder = traverser.traverse_repo()
     logger.info(f"Analyze folder: {analyze_folder}")
 
     # 2. Traverse and output the xxx.py.analyze.md file using LLM

--- a/main.py
+++ b/main.py
@@ -1,5 +1,3 @@
-import os
-
 from llm_project_helper import RepoTraverser
 from llm_project_helper.logs import logger
 


### PR DESCRIPTION
1. 使用saas列表对于仓库名字进行切割。即常见的`github.com/群组名/项目名.git`的方式。同时也修改了保存的逻辑，从原来的铺平列表变成了上面的逻辑
2. 去掉原来临时的拷贝python文件到元数据文件夹的逻辑，使用LOCAL_REPO_FOLDER从当前机器上读取文件。
3. 把main.py中的workspace去掉，全面使用const.py中的内容