### PR TITLE
Added an argparse in the main section of the code

### DIFF
--- a/llm_project_helper/repo_traverser.py
+++ b/llm_project_helper/repo_traverser.py
@@ -2,7 +2,7 @@ import os
 import json
 from dotenv import load_dotenv
 from llm_project_helper.parser.python_parser import python_analyze_code
-from loguru import logger
+from llm_project_helper.logs import logger
 from llm_project_helper.analyzer.file_summary_analyzer import FileSummaryAnalyzer
 from llm_project_helper.analyzer.code_section_analyzer import CodeSectionAnalyzer
 from llm_project_helper.const import TREE_JSON, FORCE_RE_ANALYZE, FORCE_RE_COMMENT, AVAILABLE_SAAS, WORKSPACE_DIR
@@ -88,7 +88,7 @@ class RepoTraverser:
                     logger.error(f"Error reading file {file_path}: {e}")
         return cur_ws_dir
 
-    def analyze_repo(self, analyze_folder):
+    def analyze_repo(self, analyze_folder, force_re_anlayze):
         if not analyze_folder:
             raise ValueError("Analyze folder not found")
 
@@ -102,7 +102,7 @@ class RepoTraverser:
                 analyze_file = file_path.replace('.json', '.analyze.md')
                 # if the file exists, skip the analyze and continue
                 # DONE: if FORCE_RE_ANALYZE is on, then re-do the analysis
-                if os.path.exists(analyze_file) and not FORCE_RE_ANALYZE:
+                if os.path.exists(analyze_file) and not FORCE_RE_ANALYZE and not force_re_anlayze:
                     continue
                 file_summary_analyzer = FileSummaryAnalyzer()
                 result = file_summary_analyzer.analyze_file_summary(file_path)
@@ -110,7 +110,7 @@ class RepoTraverser:
                 with open(analyze_file, 'w') as f:
                     f.write(result)
 
-    def sectioned_comment(self, analyze_folder):
+    def sectioned_comment(self, analyze_folder, force_re_comment):
         if not analyze_folder:
             raise ValueError("Analyze folder not found")
 
@@ -123,7 +123,7 @@ class RepoTraverser:
                 analyze_file = file_path.replace('.json', '.comments.json')
                 # if the file exists, skip the analyze and continue
                 # DONE: if FORCE_RE_COMMENT is on, then re-do the analysis
-                if os.path.exists(analyze_file) and not FORCE_RE_COMMENT:
+                if os.path.exists(analyze_file) and not FORCE_RE_COMMENT and not force_re_comment:
                     continue
                 # get relevant summary file: *.py.analyze.md
                 summary_file = file_path.replace('.json', '.analyze.md')

--- a/llm_project_helper/repo_traverser.py
+++ b/llm_project_helper/repo_traverser.py
@@ -11,8 +11,9 @@ load_dotenv()
 
 
 class RepoTraverser:
-    def __init__(self):
-        self.repo_path = os.getenv("REPO_PATH")
+    def __init__(self, repo_path):
+        self.repo_path = repo_path
+        # self.repo_path = os.getenv("REPO_PATH")
 
     def get_cur_ws_dir(self):
         if not self.repo_path:

--- a/llm_project_helper/repo_traverser.py
+++ b/llm_project_helper/repo_traverser.py
@@ -13,7 +13,6 @@ load_dotenv()
 class RepoTraverser:
     def __init__(self, repo_path):
         self.repo_path = repo_path
-        # self.repo_path = os.getenv("REPO_PATH")
 
     def get_cur_ws_dir(self):
         if not self.repo_path:

--- a/main.py
+++ b/main.py
@@ -14,14 +14,31 @@ if __name__ == '__main__':
         type=str,
         help="The code repo path to analyze"
     )
-    
+    # add an argument called forced-re-analyze, which is a boolean,
+    # and default is false, but if it is set, then it is true
+    parser.add_argument(
+        "--force-re-analyze",
+        action="store_true",
+        help="Force re-analyze the whole repo"
+    )
+    # add an argument called forced-re-comment, which is a boolean,
+    # and default is false, but if it is set, then it is true
+    parser.add_argument(
+        "--force-re-comment",
+        action="store_true",
+        help="Force re-comment the whole repo"
+    )
+
     args = parser.parse_args()
     repo_path = args.repo_path
-    print(f"Repo path: {repo_path}")
+    logger.info(f"Repo path: {repo_path}")
     # if the args does not have a repo_path, provide one
     if not repo_path:
         sys.exit("Please provide a repo path in --repo-path. Exiting")
-
+    force_re_analyze = args.force_re_analyze
+    logger.info(f"Force re-analyze: {force_re_analyze}")
+    force_re_comment = args.force_re_comment
+    logger.info(f"Force re-comment: {force_re_comment}")
     traverser = RepoTraverser(repo_path)
 
     # # concat current folder with workspaces; if env defined a home folder, then use that
@@ -35,7 +52,7 @@ if __name__ == '__main__':
     logger.info(f"Analyze folder: {analyze_folder}")
 
     # 2. Traverse and output the xxx.py.analyze.md file using LLM
-    traverser.analyze_repo(analyze_folder)
+    traverser.analyze_repo(analyze_folder, force_re_analyze)
 
     # 3. Analyze code section by section and output to xxx.py.comments.json
-    traverser.sectioned_comment(analyze_folder)
+    traverser.sectioned_comment(analyze_folder, force_re_comment)

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ if __name__ == '__main__':
     print(f"Repo path: {repo_path}")
     # if the args does not have a repo_path, provide one
     if not repo_path:
-        sys.exit("Please provide a repo file path. Exiting")
+        sys.exit("Please provide a repo path in --repo-path. Exiting")
 
     traverser = RepoTraverser(repo_path)
 

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+import argparse
+import sys
 from llm_project_helper import RepoTraverser
 from llm_project_helper.logs import logger
 
@@ -6,7 +8,21 @@ load_dotenv()
 
 
 if __name__ == '__main__':
-    traverser = RepoTraverser()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--repo-path", 
+        type=str,
+        help="The code repo path to analyze"
+    )
+    
+    args = parser.parse_args()
+    repo_path = args.repo_path
+    print(f"Repo path: {repo_path}")
+    # if the args does not have a repo_path, provide one
+    if not repo_path:
+        sys.exit("Please provide a repo file path. Exiting")
+
+    traverser = RepoTraverser(repo_path)
 
     # # concat current folder with workspaces; if env defined a home folder, then use that
     # workspaces_dir = os.path.join(os.getcwd(), WORKSPACE_DIR)


### PR DESCRIPTION
## options added:
1. `--repo-path`: Required. The code repo path to analyze.
    - Remove the previous envvar REPO_PATH logic
2. `--force-re-analyze`: Optional. Default is false. Force to re-analyze the whole repo by LLM, ignoring the previous analyze files. 
    - In tandem with `const.py/FORCE-RE-ANALYZE`, both of them are false in default, but if either turns true, then re-do is needed.
3. `--force-re-comment`: Optional. Default is false. Force to re-comment the whole repo by LLM, ignoring the previous comment files.
    - In tandem with `const.py/FORCE-RE-COMMENT`, both of them are false in default, but if either turns true, then re-do is needed.