### PR TITLE
Parse java

### DIFF
--- a/llm_project_helper/analyzer/code_section_analyzer.py
+++ b/llm_project_helper/analyzer/code_section_analyzer.py
@@ -114,9 +114,10 @@ class CodeSectionAnalyzer:
 
     def process_functions(self, functions):
         res = []
-        for func_name, details in functions.items():
-            line_number = details["line_number"]
-            end_line_number = details["end_line_number"]
-            # contstruct a line_no, end_line_no pair
-            res.append((line_number, end_line_number))
+        if functions is not None:
+            for func_name, details in functions.items():
+                line_number = details["line_number"]
+                end_line_number = details["end_line_number"]
+                # contstruct a line_no, end_line_no pair
+                res.append((line_number, end_line_number))
         return res

--- a/llm_project_helper/const.py
+++ b/llm_project_helper/const.py
@@ -17,6 +17,7 @@ from enum import Enum
 
 class Language(Enum):
     PYTHON = "python"
+    JAVA = "java"
     UNKNOWN = "unknown"
 
 def get_llm_project_helper_package_root():

--- a/llm_project_helper/parser/treesitter_parser.py
+++ b/llm_project_helper/parser/treesitter_parser.py
@@ -89,9 +89,11 @@ if __name__ == "__main__":
     # file_name = '~/code/github.com/c4fun/zhipuai-playground/samples/gradio-glm4.py'
     # file_name = '~/code/github.com/geekan/MetaGPT/metagpt/provider/zhipuai_api.py'
     # file_name = '~/code/github.com/geekan/MetaGPT/setup.py'
-    # file_name = '~/code/github.com/geekan/MetaGPT/tests/metagpttools/test_azure_tts.py'
 
-    file_name = '~/code/github.com/rvesse/airline/airline-prompts/src/main/java/com/github/rvesse/airline/prompts/Prompt.java'
+    # file_name = '~/code/github.com/rvesse/airline/airline-prompts/src/main/java/com/github/rvesse/airline/prompts/Prompt.java'
+    # file_name = '~/code/github.com/rvesse/airline/airline-core/src/main/java/com/github/rvesse/airline/Accessor.java'
+    file_name = '~/code/github.com/rvesse/airline/airline-core/src/main/java/com/github/rvesse/airline/ChannelFactory.java'
+
     expanded_path = os.path.expanduser(file_name)
 
     result = analyze_code_from_file(expanded_path)

--- a/llm_project_helper/parser/treesitter_parser.py
+++ b/llm_project_helper/parser/treesitter_parser.py
@@ -91,8 +91,8 @@ if __name__ == "__main__":
     # file_name = '~/code/github.com/geekan/MetaGPT/setup.py'
 
     # file_name = '~/code/github.com/rvesse/airline/airline-prompts/src/main/java/com/github/rvesse/airline/prompts/Prompt.java'
-    # file_name = '~/code/github.com/rvesse/airline/airline-core/src/main/java/com/github/rvesse/airline/Accessor.java'
-    file_name = '~/code/github.com/rvesse/airline/airline-core/src/main/java/com/github/rvesse/airline/ChannelFactory.java'
+    file_name = '~/code/github.com/rvesse/airline/airline-core/src/main/java/com/github/rvesse/airline/Accessor.java'
+    # file_name = '~/code/github.com/rvesse/airline/airline-core/src/main/java/com/github/rvesse/airline/ChannelFactory.java'
 
     expanded_path = os.path.expanduser(file_name)
 

--- a/llm_project_helper/parser/treesitter_parser.py
+++ b/llm_project_helper/parser/treesitter_parser.py
@@ -59,15 +59,18 @@ def analyze_code_from_file(file_name):
 
             logger.debug(f'Method async: {function.async_method_flag}')
 
+        # In java, the global_variables is N/A; and the main_block is not implemented
         global_variables = treesitter_result_nodes.global_variables
-        for global_variable in global_variables:
-            logger.debug(f'Global variable: {global_variable.name}')
-            logger.debug(f'Global variable line number: {global_variable.line_number}')
+        if global_variables is not None:
+            for global_variable in global_variables:
+                logger.debug(f'Global variable: {global_variable.name}')
+                logger.debug(f'Global variable line number: {global_variable.line_number}')
 
         main_block = treesitter_result_nodes.main_block
-        logger.debug(f'Main block: {main_block}')
-        # logger.debug(f'Main block source code: {main_block.source_code}')
-        
+        if main_block is not None:
+            logger.debug(f'Main block: {main_block}')
+            logger.debug(f'Main block source code: {main_block.source_code}')
+
         # result = {
         #     "imports": imports,
         #     "classes": classes,
@@ -83,9 +86,11 @@ if __name__ == "__main__":
 
     # Example usage with a file path
     # file_name = '~/code/github.com/c4fun/zhipuai-playground/samples/gradio-glm4.py'
-    file_name = '~/code/github.com/geekan/MetaGPT/metagpt/provider/zhipuai_api.py'
+    # file_name = '~/code/github.com/geekan/MetaGPT/metagpt/provider/zhipuai_api.py'
     # file_name = '~/code/github.com/geekan/MetaGPT/setup.py'
-    # file_name = '~/code/github.com/geekan/MetaGPT/tests/metagpt/tools/test_azure_tts.py'
+    # file_name = '~/code/github.com/geekan/MetaGPT/tests/metagpttools/test_azure_tts.py'
+
+    file_name = '~/code/github.com/rvesse/airline/airline-prompts/src/main/java/com/github/rvesse/airline/prompts/Prompt.java'
     expanded_path = os.path.expanduser(file_name)
 
     result = analyze_code_from_file(expanded_path)

--- a/llm_project_helper/parser/treesitter_parser.py
+++ b/llm_project_helper/parser/treesitter_parser.py
@@ -46,18 +46,19 @@ def analyze_code_from_file(file_name):
             logger.debug(f'Class variables: {class_info.class_variables}')
 
         functions = treesitter_result_nodes.functions
-        for function_name, function in functions.items():
-            method_name_for_terminal_print = utils.get_bold_text(function.name)
-            logger.debug(f'Method name: {method_name_for_terminal_print}')
-            # logger.debug(f'Method source code: {function.source_code}')
-            logger.debug(f'Method variables: {function.method_variables}')
-            logger.debug(f'Method parameters: {function.parameters}')
+        if functions is not None:
+            for function_name, function in functions.items():
+                method_name_for_terminal_print = utils.get_bold_text(function.name)
+                logger.debug(f'Method name: {method_name_for_terminal_print}')
+                # logger.debug(f'Method source code: {function.source_code}')
+                logger.debug(f'Method variables: {function.method_variables}')
+                logger.debug(f'Method parameters: {function.parameters}')
 
-            logger.debug(f'Method line number: {function.line_number}')
-            logger.debug(f'Method end line number: {function.end_line_number}')
-            logger.debug(f'Method decorator_line_number: {function.decorator_line_number}')
+                logger.debug(f'Method line number: {function.line_number}')
+                logger.debug(f'Method end line number: {function.end_line_number}')
+                logger.debug(f'Method decorator_line_number: {function.decorator_line_number}')
 
-            logger.debug(f'Method async: {function.async_method_flag}')
+                logger.debug(f'Method async: {function.async_method_flag}')
 
         # In java, the global_variables is N/A; and the main_block is not implemented
         global_variables = treesitter_result_nodes.global_variables

--- a/llm_project_helper/repo_traverser.py
+++ b/llm_project_helper/repo_traverser.py
@@ -1,12 +1,13 @@
 import os
 import json
+from llm_project_helper import utils
 from dotenv import load_dotenv
 from llm_project_helper.parser.python_parser import python_analyze_code
 from llm_project_helper.parser.treesitter_parser import analyze_code_from_file
 from llm_project_helper.logs import logger
 from llm_project_helper.analyzer.file_summary_analyzer import FileSummaryAnalyzer
 from llm_project_helper.analyzer.code_section_analyzer import CodeSectionAnalyzer
-from llm_project_helper.const import TREE_JSON, FORCE_RE_ANALYZE, FORCE_RE_COMMENT, AVAILABLE_SAAS, WORKSPACE_DIR
+from llm_project_helper.const import TREE_JSON, FORCE_RE_ANALYZE, FORCE_RE_COMMENT, AVAILABLE_SAAS, WORKSPACE_DIR, Language
 
 load_dotenv()
 
@@ -55,8 +56,9 @@ class RepoTraverser:
 
         for root, dirs, files in os.walk(self.repo_path):
             for file in files:
-                # judge if the file ends with *.py, if not, continue
-                if not file.endswith(".py"):
+                file_extension = utils.get_file_extension(file)
+                programming_language = utils.get_programming_language(file_extension)
+                if programming_language is Language.UNKNOWN:
                     continue
                 file_path = os.path.join(root, file)
                 relative_path = os.path.relpath(file_path, self.repo_path)

--- a/llm_project_helper/treesitter/__init__.py
+++ b/llm_project_helper/treesitter/__init__.py
@@ -8,3 +8,4 @@ from llm_project_helper.treesitter.treesitter import (Treesitter,
                                                       TreesitterGlobalVariableNode,
                                                       )
 from llm_project_helper.treesitter.treesitter_py import TreesitterPython
+from llm_project_helper.treesitter.treesitter_java import TreesitterJava

--- a/llm_project_helper/treesitter/__init__.py
+++ b/llm_project_helper/treesitter/__init__.py
@@ -6,6 +6,6 @@ from llm_project_helper.treesitter.treesitter import (Treesitter,
                                                       TreesitterGeneralVariableNode,
                                                       TreesitterGeneralParameterNode,
                                                       TreesitterGlobalVariableNode,
-                                                      )
+                                                      TreesitterInferfaceNode,)
 from llm_project_helper.treesitter.treesitter_py import TreesitterPython
 from llm_project_helper.treesitter.treesitter_java import TreesitterJava

--- a/llm_project_helper/treesitter/treesitter.py
+++ b/llm_project_helper/treesitter/treesitter.py
@@ -54,6 +54,17 @@ class TreesitterClassNode(BaseModel):
     class Config:
         arbitrary_types_allowed = True
 
+class TreesitterInferfaceNode(BaseModel):
+    line_number: int
+    end_line_number: int
+    name: str | bytes | None
+    methods: dict[str, TreesitterMethodNode] | None
+    node: tree_sitter.Node = Field(..., exclude=True)
+    source_code: str | None = Field(exclude=True)
+    interface_variables: list[TreesitterGeneralVariableNode] | None
+    class Config:
+        arbitrary_types_allowed = True
+
 class TreesitterImportNode(BaseModel):
     import_identifier: str | None
     line_number: int
@@ -80,6 +91,7 @@ class TreesitterResultNode(BaseModel):
     functions: dict[str, TreesitterMethodNode] | None
     global_variables: list[TreesitterGlobalVariableNode] | None
     main_block: TreesitterMainBlockNode | None
+    interfaces: dict[str, TreesitterInferfaceNode] | None
     class Config:
         arbitrary_types_allowed = True
 
@@ -116,6 +128,8 @@ class Treesitter(ABC):
         logger.debug(f'typeof global_variables: {type(global_variables)}')
         main_block=self._query_main_block(self.tree.root_node)
         logger.debug(f'typeof main_block: {type(main_block)}')
+        # interfaces=self._query_interfaces(self.tree.root_node)
+        # logger.debug(f'typeof interfaces: {type(interfaces)}')
 
         all_result = TreesitterResultNode(
             imports=imports,
@@ -123,11 +137,15 @@ class Treesitter(ABC):
             functions=functions,
             global_variables=global_variables,
             main_block=main_block,
+            interfaces=None,
         )
         # logger.debug(f'all_result: {all_result}')
         return all_result
     
-    def _query_functions(self, node: tree_sitter.Node) -> list:
+    def _query_interfaces(self, node: tree_sitter.Node):
+        return None
+    
+    def _query_functions(self, node: tree_sitter.Node) -> dict:
         result = {}
         query = self.language.query("""
             (function_definition

--- a/llm_project_helper/treesitter/treesitter.py
+++ b/llm_project_helper/treesitter/treesitter.py
@@ -44,6 +44,7 @@ class TreesitterMethodNode(BaseModel):
 
 class TreesitterClassNode(BaseModel):
     name: str | bytes | None
+    constructors: dict[str, TreesitterMethodNode] | None
     methods: dict[str, TreesitterMethodNode] | None
     class_variables: list[TreesitterGeneralVariableNode] | None
     doc_comment: str | None
@@ -308,6 +309,7 @@ class Treesitter(ABC):
 
                 classes[name] = TreesitterClassNode(
                     name=name,
+                    constructors=None,
                     methods=methods,
                     class_variables=class_variables,
                     doc_comment=doc_comment,

--- a/llm_project_helper/treesitter/treesitter_java.py
+++ b/llm_project_helper/treesitter/treesitter_java.py
@@ -1,0 +1,322 @@
+import tree_sitter
+
+from llm_project_helper.const import Language
+from llm_project_helper.treesitter.treesitter import (Treesitter,
+                                                      TreesitterGeneralVariableNode,
+                                                      TreesitterGeneralParameterNode,
+                                                      TreesitterMethodNode,
+                                                      TreesitterClassNode,
+                                                      TreesitterImportNode,
+                                                      TreesitterGlobalVariableNode,
+                                                      TreesitterMainBlockNode,
+                                                      TreesitterResultNode,)
+from llm_project_helper.treesitter.treesitter_registry import TreesitterRegistry
+from llm_project_helper.logs import logger
+
+
+class TreesitterJava(Treesitter):
+    def __init__(self):
+        super().__init__(
+            Language.JAVA, "function_definition", "identifier", "expression_statement"
+        )
+
+    def parse(self, file_bytes: bytes) -> list[TreesitterMethodNode]:
+        self.tree = self.parser.parse(file_bytes)
+        
+        imports=self._query_imports(self.tree.root_node)
+        logger.debug(f'typeof imports: {type(imports)}')
+        classes=self._query_classes(self.tree.root_node)
+        logger.debug(f'typeof classes: {type(classes)}')
+        functions=self._query_functions(self.tree.root_node)
+        logger.debug(f'typeof functions: {type(functions)}')
+        # global_variables=self._query_global_variables(self.tree.root_node)
+        # logger.debug(f'typeof global_variables: {type(global_variables)}')
+        # main_block=self._query_main_block(self.tree.root_node)
+        # logger.debug(f'typeof main_block: {type(main_block)}')
+
+        all_result = TreesitterResultNode(
+            imports=imports,
+            classes=classes,
+            functions=functions,
+            global_variables=None,
+            main_block=None,
+        )
+        # logger.debug(f'all_result: {all_result}')
+        return all_result
+
+    def _query_imports(self, node: tree_sitter.Node) -> list:
+        # TODO: This is a simplified example; actual parsing may require more detailed handling
+        imports = []
+        query = self.language.query(f"(import_declaration) @import")
+        for captured_node, _ in query.captures(node):
+            logger.debug(f'captured_node.text.decode(): {captured_node.text.decode()}')
+            imports.append(TreesitterImportNode(
+                import_identifier=captured_node.text.decode(),
+                line_number=captured_node.start_point[0]+1,
+                from_module=None,
+                node=captured_node,
+                source_code=None
+            ))
+        logger.debug(f'imports: {imports}')
+        return imports
+
+    def _query_classes(self, node: tree_sitter.Node) -> dict:
+        classes = {}
+        # Java 的类定义查询
+        query = self.language.query("""
+            (class_declaration
+                name: (identifier) @class_name
+                body: (class_body) @body
+            ) @class
+        """)
+        captures = query.captures(node)
+
+        for captured_node, capture_name in captures:
+            if capture_name == 'class':
+                name_node = captured_node.child_by_field_name('name')
+                if name_node:
+                    name = name_node.text.decode('utf-8')
+                    methods = self._query_methods_within_class(captured_node)
+                    # Java 类中的变量也可能在这里处理
+                    class_variables = self._extract_class_variables(captured_node)
+                    # TODO: 添加 doc_comment 的处理
+                    line_number = captured_node.start_point[0] + 1
+                    end_line_number = captured_node.end_point[0] + 1
+
+                    classes[name] = TreesitterClassNode(
+                        name=name,
+                        methods=methods,
+                        class_variables=class_variables,
+                        doc_comment=None,  # Java 文档注释的处理
+                        line_number=line_number,
+                        end_line_number=end_line_number,
+                        node=captured_node,
+                        source_code=None
+                    )
+        return classes
+
+    def _query_functions(self, node: tree_sitter.Node) -> dict:
+        functions = {}
+        # Java 的方法定义查询
+        query = self.language.query("""
+            (method_declaration
+                name: (identifier) @method_name
+                parameters: (formal_parameters) @params
+                body: (block) @body
+            ) @method
+        """)
+        captures = query.captures(node)
+
+        for captured_node, capture_name in captures:
+            if capture_name == 'method':
+                name_node = captured_node.child_by_field_name('name')
+                if name_node:
+                    name = name_node.text.decode('utf-8')
+                    parameters = self._extract_parameters(captured_node)
+                    line_number = captured_node.start_point[0] + 1
+                    end_line_number = captured_node.end_point[0] + 1
+                    method_variables = self._extract_method_variables(captured_node)
+                    # TODO: 添加 async_method_flag 和 decorator_line_number 的处理（如果在 Java 中适用）
+
+                    functions[name] = TreesitterMethodNode(
+                        name=name,
+                        doc_comment=None,  # Java 文档注释的处理
+                        node=captured_node,
+                        source_code=None,
+                        method_variables=method_variables,
+                        parameters=parameters,
+                        line_number=line_number,
+                        end_line_number=end_line_number,
+                        async_method_flag=False,  # 根据 Java 语法适当调整
+                        decorator_line_number=None  # Java 注解处理
+                    )
+        return functions
+
+    def _query_methods_within_class(self, class_node: tree_sitter.Node):
+        result = {}
+        query = self.language.query("""
+            (method_declaration
+                name: (identifier) @function_name
+                parameters: (formal_parameters) @params
+                body: (block) @body
+            ) @function
+        """)
+        captures = query.captures(class_node)
+
+        for captured_node, _ in captures:
+            if captured_node.type == 'method_declaration':
+                name = self._query_method_name(captured_node)
+                doc_comment = self._extract_doc_comment(captured_node)
+                method_variables = self._extract_method_variables(captured_node)
+                parameters = self._extract_parameters(captured_node)
+                line_number = captured_node.start_point[0] + 1
+                end_line_number = captured_node.end_point[0] + 1
+                async_method_flag = self._check_async_method(captured_node)
+                decorator_line_number = self._extract_decorator_line_number(captured_node)
+
+                result[name] = TreesitterMethodNode(
+                    name=name,
+                    doc_comment=doc_comment,
+                    node=captured_node,
+                    source_code=captured_node.text.decode('utf-8'),
+                    method_variables=method_variables,
+                    parameters=parameters,
+                    line_number=line_number,
+                    end_line_number=end_line_number,
+                    async_method_flag=async_method_flag,
+                    decorator_line_number=decorator_line_number
+                )
+        return result
+
+    def _query_method_name(self, node: tree_sitter.Node):
+        # Assuming 'method_declaration' nodes have a direct 'identifier' child for the name.
+        name_node = node.child_by_field_name('name')
+        if name_node is not None and name_node.type == 'identifier':
+            return name_node.text.decode('utf-8')
+        # Fallback or error handling if name extraction fails
+        return "UnnamedMethod"  # Or handle this case as appropriate
+
+    def _extract_decorator_line_number(self, node: tree_sitter.Node):
+        query_str = """
+                (annotation) @annotation
+        """
+        query = self.language.query(query_str)
+        captures = query.captures(node)
+        for captured_node, capture_name in captures:
+            if capture_name == 'annotation':
+                return captured_node.start_point[0] + 1
+        return None
+
+
+
+    def _extract_method_variables(self, node: tree_sitter.Node):
+        # Example: Extract variables declared at the start of a function
+        variables = []
+        query = self.language.query("""
+            (method_declaration body: (block (expression_statement (assignment_expression) @assignment)))
+        """)
+        captures = query.captures(node)
+        for captured_node, _ in captures:
+            variable_name = captured_node.child_by_field_name('left').text.decode('utf-8')
+            # retrieve the line_number of the variable
+            line_number = captured_node.start_point[0] + 1
+            # append the variable_name and line_number to a dict
+            variables.append({'name': variable_name, 'line_number': line_number})
+        return variables
+
+    def _extract_class_variables(self, class_node: tree_sitter.Node):
+        class_variables = []
+        # 更新了查询字符串以匹配 Java 中的字段声明
+        query_str = """
+            (class_declaration
+                body: (class_body
+                    (field_declaration
+                        declarator: (variable_declarator
+                            name: (identifier) @variable_name
+                        )
+                    )
+                )
+            )
+        """
+        query = self.language.query(query_str)
+        captures = query.captures(class_node)
+
+        for captured_node, capture_name in captures:
+            if capture_name == 'variable_name':
+                variable_name = captured_node.text.decode('utf-8')
+                line_number = captured_node.start_point[0] + 1
+                # 可以在这里添加更多逻辑，比如提取变量类型等
+                class_variables.append(TreesitterGeneralVariableNode(
+                    name=variable_name,
+                    line_number=line_number
+                ))
+
+        return class_variables
+    
+    def _query_global_variables(self, class_node: tree_sitter.Node):
+        # 全局变量在 Java 中一般指的是静态变量，可以在类级别定义。注意这里的node应该是class_node，而不是一般的node
+        class_variables = []
+        # 查询静态变量的字符串
+        query_str = """
+            (class_declaration
+                body: (class_body
+                    (field_declaration
+                        (modifier) @modifier
+                        declarator: (variable_declarator
+                            name: (identifier) @variable_name
+                        )
+                    )
+                )
+            )
+        """
+        query = self.language.query(query_str)
+        captures = query.captures(class_node)
+
+        for captured_node, capture_name in captures:
+            if capture_name == 'variable_name':
+                # 检查是否有静态修饰符
+                modifier_node = captured_node.prev_sibling
+                while modifier_node is not None:
+                    if modifier_node.type == 'modifier' and 'static' in modifier_node.text.decode('utf-8'):
+                        variable_name = captured_node.text.decode('utf-8')
+                        line_number = captured_node.start_point[0] + 1
+                        class_variables.append(TreesitterGeneralVariableNode(
+                            name=variable_name,
+                            line_number=line_number
+                        ))
+                        break  # 找到静态修饰符后就不需要继续查找
+                    modifier_node = modifier_node.prev_sibling
+
+        return class_variables
+
+    def _query_main_block(self, root_node: tree_sitter.Node):
+        # 构建查询字符串以查找 main 方法
+        query_str = """
+            (class_declaration
+                body: (class_body
+                    (method_declaration
+                        modifiers: (modifiers
+                            (modifier) @public
+                            (modifier) @static
+                        )
+                        type: (void_type) @return_type
+                        name: (identifier) @method_name
+                        parameters: (formal_parameters
+                            (formal_parameter
+                                type: (type_identifier) @param_type
+                                name: (identifier) @param_name
+                            )
+                        )
+                        body: (block) @body
+                    ) @main_method
+                    (#match? @method_name "main")
+                    (#match? @param_type "String\\[\\]")
+                )
+            )
+        """
+        query = self.language.query(query_str)
+        captures = query.captures(root_node)
+
+        main_blocks = []
+
+        for captured_node, capture_name in captures:
+            if capture_name == 'body':
+                # 提取 main 方法的信息
+                source_code = captured_node.text.decode('utf-8')
+                line_number = captured_node.start_point[0] + 1
+                end_line_number = captured_node.end_point[0] + 1
+
+                main_blocks.append(TreesitterMainBlockNode(
+                    node=captured_node,
+                    source_code=source_code,
+                    line_number=line_number,
+                    end_line_number=end_line_number
+                ))
+
+        return main_blocks
+
+
+
+# Register the TreesitterJava class in the registry
+TreesitterRegistry.register_treesitter(Language.JAVA, TreesitterJava)
+

--- a/llm_project_helper/treesitter/treesitter_java.py
+++ b/llm_project_helper/treesitter/treesitter_java.py
@@ -27,8 +27,8 @@ class TreesitterJava(Treesitter):
         logger.debug(f'typeof imports: {type(imports)}')
         classes=self._query_classes(self.tree.root_node)
         logger.debug(f'typeof classes: {type(classes)}')
-        functions=self._query_functions(self.tree.root_node)
-        logger.debug(f'typeof functions: {type(functions)}')
+        # functions=self._query_functions(self.tree.root_node)
+        # logger.debug(f'typeof functions: {type(functions)}')
         # global_variables=self._query_global_variables(self.tree.root_node)
         # logger.debug(f'typeof global_variables: {type(global_variables)}')
         # main_block=self._query_main_block(self.tree.root_node)
@@ -37,7 +37,7 @@ class TreesitterJava(Treesitter):
         all_result = TreesitterResultNode(
             imports=imports,
             classes=classes,
-            functions=functions,
+            functions=None,
             global_variables=None,
             main_block=None,
         )

--- a/llm_project_helper/utils.py
+++ b/llm_project_helper/utils.py
@@ -16,6 +16,7 @@ def get_programming_language(file_extension: str) -> Language:
     """
     language_mapping = {
         ".py": Language.PYTHON,
+        ".java": Language.JAVA,
     }
     return language_mapping.get(file_extension, Language.UNKNOWN)
 


### PR DESCRIPTION
1. 加上Java的Treesitter。
2. 根据Java的特性，在总体加上interfaces特性。
3. Language中加上Java。目前有Java和Python两种语言
4. Repo_traverser逻辑改成从Language中读取语言，会解析Language中所有语言。
5. [llm_project_helper/analyzer/code_section_analyzer.py](https://github.com/c4fun/llm-project-helper/compare/parse-java?expand=1#diff-05d5c54c95e506a56a585df3754c7df9442ab62a915c7f5347ad64d9be08223d) 中加上对functions的存在性判断。